### PR TITLE
Python 2+3 compatibility for sqlalchemy phoenix

### DIFF
--- a/pyphoenix/sqlalchemy_phoenix.py
+++ b/pyphoenix/sqlalchemy_phoenix.py
@@ -11,10 +11,10 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+from future.standard_library import install_aliases
+install_aliases()
 
-
-import urlparse
-import urllib
+import urllib.parse
 import pyphoenix
 
 from sqlalchemy.engine.default import DefaultDialect
@@ -49,11 +49,11 @@ class PhoenixDialect(DefaultDialect):
         return pyphoenix
 
     def create_connect_args(self, url):
-        phoenix_url = urlparse.urlunsplit(urlparse.SplitResult(
+        phoenix_url = urllib.parse.urlunsplit(urllib.parse.SplitResult(
             scheme='http',
             netloc='{}:{}'.format(url.host, url.port or 8765),
             path='/',
-            query=urllib.urlencode(url.query),
+            query=urllib.parse.urlencode(url.query),
             fragment='',
         ))
         return [phoenix_url], {'autocommit': True}


### PR DESCRIPTION
Changed sqlalchemy_phoenix.py to be Python 2 + 3 compatible.
Uses the same install_aliases() functionality as in avatica.py.